### PR TITLE
Feature/get size endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,10 @@ backend/__pycache__/*
 *.py[cod]
 backend/app/testing/
 backend/app/uploaded_files/
+*.pyc
+*.pyo
+*.pyd
+.Python
+env/
+.git
+*.db

--- a/backend/app/controllers/files_controller.py
+++ b/backend/app/controllers/files_controller.py
@@ -2,43 +2,70 @@ import os
 import shutil
 import threading
 import time
-from flask import Blueprint, request, redirect, jsonify, render_template
+from flask import Blueprint, request, redirect, jsonify
 from flask import current_app
 from app.extensions.ext import socketio,emit
 from werkzeug.utils import secure_filename
 from app.utils.functions import debug_message
-from app.utils.filesystem import format_directory,secure_path,have_files,get_path_size,get_total_files_and_directories, get_filetype
-from datetime import datetime
+from app.utils.filesystem import format_directory,secure_path,have_files,get_path_size,get_total_files_and_directories, get_filetype,delete_first_bar
 
-file_bp = Blueprint('api', __name__, url_prefix='/api') 
-
+file_bp = Blueprint('api', __name__, url_prefix='/api/') 
 
 @file_bp.route('/', methods=['POST'])
-def upload_file() -> dict: # Json dict, redirect
+@file_bp.route('/<path:folder_path>', methods=['POST'])
+def upload_file(folder_path='') -> dict: # Json dict, redirect
+    
+    base_path = os.path.join(current_app.config['UPLOADED_FILES'],folder_path)
 
     if request.method == 'POST':
-        if 'file' not in request.files:
-            return jsonify({'message':'Missing file in request'}),422
-        
-        file = request.files['file']
 
-        if file.filename == '':
-            return jsonify({'message':'No selected file'}),404
+        if 'file' in request.files:
+            file = request.files['file']
+            if file and file.filename != '':
+                filename = secure_filename(file.filename)
+                save_path = os.path.join(base_path, filename)
+                file.save(save_path)
+                return jsonify({'message': '¡File uploaded successfully!'}), 200
+            else:
+                return jsonify({'message': 'No file selected'}), 400
 
-        if file:
-            filename = secure_filename(file.filename)
-            file.save(os.path.join(current_app.config['UPLOADED_FILES'],filename))
-            return jsonify({'message':'¡File uploaded successfully!'}),200
-    
+        if folder_path:
+            if not os.path.exists(base_path):
+                os.makedirs(base_path)
+                return jsonify({'message': '¡Directory created successfully!'}), 200
+            else:
+                return jsonify({'message': 'Directory already exists'}), 409
+
     return redirect('/')
+
+@file_bp.route('/<old_name>/<new_name>', methods=['PATCH'])
+@file_bp.route('/<path:folder_path>/<old_name>/<new_name>', methods=['PATCH'])
+def rename_file(old_name, new_name, folder_path=''):
+
+    base_path = current_app.config['UPLOADED_FILES']
+
+    old_path = os.path.join(base_path, folder_path, old_name)
+    new_path = os.path.join(base_path, folder_path, new_name)
+
+    if os.path.exists(old_path):
+        try:
+            os.rename(old_path, new_path)
+            return jsonify({'message': f'¡{"Directory" if os.path.isdir(new_path) else "File"} renamed successfully!'}), 200
+        except Exception as e:
+            return jsonify({'message': f'Error renaming file or directory: {str(e)}'}), 500
+    
+    else:
+        return jsonify({'message': '¡File or directory not found!'}), 404
+
 
 @file_bp.route('/<file_name>', methods=['DELETE'])
 def delete_file(file_name) -> dict: # Json dict, redirect
+    
+    file_path = os.path.join(current_app.config['UPLOADED_FILES'],file_name) 
 
-    if request.method == 'DELETE':
+    if request.method == 'DELETE' and os.path.exists(file_path):
         try:
             file_name = secure_filename(file_name)
-            file_path = os.path.join(current_app.config['UPLOADED_FILES'],file_name) 
             if os.path.isfile(file_path):
                 os.remove(os.path.join(current_app.config['UPLOADED_FILES'],file_name))
                 return jsonify({'message':'¡File deleted successfully!'}),200
@@ -49,17 +76,14 @@ def delete_file(file_name) -> dict: # Json dict, redirect
 
 
         except FileNotFoundError:
-            return jsonify({'message':'¡File not found!'}),404
-                
-
+            return jsonify({'message':f'¡File or directory not found!'}),404
+               
     
-    return redirect('/')
+    return jsonify({'message':f'¡File or directory not found!'}),404
  
 @file_bp.route('/', methods=['GET'])
 @file_bp.route('/<path:url>', methods=['GET'])
 def all_files(url='/') -> dict: # Json dict  
-
-    start_count = datetime.now()
 
     all_files_and_directories = {}
     base_path = current_app.config['UPLOADED_FILES'] 
@@ -71,8 +95,9 @@ def all_files(url='/') -> dict: # Json dict
             final_path = os.path.join(base_path, url.strip('/'))
             all_files_and_directories['path']        = ('/api'+url if url == '/' else '/api'+'/'+url)
             all_files_and_directories['files']       = [{'name':f,'type':get_filetype(final_path + '/' + f)} for f in os.listdir(final_path) if os.path.isfile(os.path.join(final_path, f))] 
-            all_files_and_directories['directories'] = [{'isEmpty': have_files(final_path + '/' + d), 'name':d} for d in os.listdir(final_path) if os.path.isdir(os.path.join(final_path, d))]
-            all_files_and_directories['actions']     = {'label':'Delete', 'method':'DELETE', 'url':('/api'+url if url == '/' else '/api'+'/'+url)}
+            all_files_and_directories['directories'] = sorted([{'isEmpty': have_files(final_path + '/' + d), 'name':d} for d in os.listdir(final_path) if os.path.isdir(os.path.join(final_path, d))], key= lambda x: x['isEmpty'])
+            if url != '/': # Operations are not allowed in the root path '/'.
+                all_files_and_directories['actions']   = [{'label':'Delete', 'method':'DELETE', 'url':'/api/'+url}, {'label':'Rename', 'method':'PATCH', 'url':'/api/'+url+'/old_name/new_name'},{'label':'Get path size', 'method':'GET','url':'/api/size?path='+url}]
 
         except FileNotFoundError:
 
@@ -82,15 +107,30 @@ def all_files(url='/') -> dict: # Json dict
     else:
         return jsonify({'error': 'Path not allowed'}), 404
     
-    end_count = datetime.now()
-
-    response_time = end_count - start_count
-
-    debug_message(f" Request /api/ : Arg path value '{url}' : Response time {response_time}",current_app.config['DEBUG_MODE'])
-
-
     return jsonify(all_files_and_directories)
 
+
+@file_bp.route('/size', methods=['GET'])
+def get_file_size():
+
+    base_path = current_app.config['UPLOADED_FILES'] 
+        
+    path_parameter = request.args.get('path')
+    if not path_parameter:
+        return jsonify({'message':f'¡Missing parameter path!'}),404
+
+    path_parameter =  (delete_first_bar(path_parameter) if path_parameter.startswith('/') else path_parameter)
+    file_path = os.path.join(base_path, path_parameter)
+
+    if not secure_path(base_path, path_parameter) or not os.path.exists(file_path):
+        return jsonify({'message':f'¡File or directory not found!'}),404
+
+    return jsonify({'path':'/' + path_parameter.strip('/'),
+                    'name': os.path.basename(file_path),
+                    'size':get_path_size(file_path)}
+                    )
+
+    
 def check_files_thread(app,sid):
 
     with app.app_context():
@@ -103,7 +143,6 @@ def check_files_thread(app,sid):
             if new_files != aux_new_files:
                 aux_new_files = new_files
                 socketio.emit('new_files', {'message': 'Nuevo archivo'}, to=sid)
-
 
 @socketio.on('connect')
 def on_connect():

--- a/backend/app/controllers/files_controller.py
+++ b/backend/app/controllers/files_controller.py
@@ -2,70 +2,43 @@ import os
 import shutil
 import threading
 import time
-from flask import Blueprint, request, redirect, jsonify
+from flask import Blueprint, request, redirect, jsonify, render_template
 from flask import current_app
 from app.extensions.ext import socketio,emit
 from werkzeug.utils import secure_filename
 from app.utils.functions import debug_message
 from app.utils.filesystem import format_directory,secure_path,have_files,get_path_size,get_total_files_and_directories, get_filetype
+from datetime import datetime
 
-file_bp = Blueprint('api', __name__, url_prefix='/api/') 
+file_bp = Blueprint('api', __name__, url_prefix='/api') 
+
 
 @file_bp.route('/', methods=['POST'])
-@file_bp.route('/<path:folder_path>', methods=['POST'])
-def upload_file(folder_path='') -> dict: # Json dict, redirect
-    
-    base_path = os.path.join(current_app.config['UPLOADED_FILES'],folder_path)
+def upload_file() -> dict: # Json dict, redirect
 
     if request.method == 'POST':
+        if 'file' not in request.files:
+            return jsonify({'message':'Missing file in request'}),422
+        
+        file = request.files['file']
 
-        if 'file' in request.files:
-            file = request.files['file']
-            if file and file.filename != '':
-                filename = secure_filename(file.filename)
-                save_path = os.path.join(base_path, filename)
-                file.save(save_path)
-                return jsonify({'message': '¡File uploaded successfully!'}), 200
-            else:
-                return jsonify({'message': 'No file selected'}), 400
+        if file.filename == '':
+            return jsonify({'message':'No selected file'}),404
 
-        if folder_path:
-            if not os.path.exists(base_path):
-                os.makedirs(base_path)
-                return jsonify({'message': '¡Directory created successfully!'}), 200
-            else:
-                return jsonify({'message': 'Directory already exists'}), 409
-
-    return redirect('/')
-
-@file_bp.route('/<old_name>/<new_name>', methods=['PATCH'])
-@file_bp.route('/<path:folder_path>/<old_name>/<new_name>', methods=['PATCH'])
-def rename_file(old_name, new_name, folder_path=''):
-
-    base_path = current_app.config['UPLOADED_FILES']
-
-    old_path = os.path.join(base_path, folder_path, old_name)
-    new_path = os.path.join(base_path, folder_path, new_name)
-
-    if os.path.exists(old_path):
-        try:
-            os.rename(old_path, new_path)
-            return jsonify({'message': f'¡{"Directory" if os.path.isdir(new_path) else "File"} renamed successfully!'}), 200
-        except Exception as e:
-            return jsonify({'message': f'Error renaming file or directory: {str(e)}'}), 500
+        if file:
+            filename = secure_filename(file.filename)
+            file.save(os.path.join(current_app.config['UPLOADED_FILES'],filename))
+            return jsonify({'message':'¡File uploaded successfully!'}),200
     
-    else:
-        return jsonify({'message': '¡File or directory not found!'}), 404
-
+    return redirect('/')
 
 @file_bp.route('/<file_name>', methods=['DELETE'])
 def delete_file(file_name) -> dict: # Json dict, redirect
-    
-    file_path = os.path.join(current_app.config['UPLOADED_FILES'],file_name) 
 
-    if request.method == 'DELETE' and os.path.exists(file_path):
+    if request.method == 'DELETE':
         try:
             file_name = secure_filename(file_name)
+            file_path = os.path.join(current_app.config['UPLOADED_FILES'],file_name) 
             if os.path.isfile(file_path):
                 os.remove(os.path.join(current_app.config['UPLOADED_FILES'],file_name))
                 return jsonify({'message':'¡File deleted successfully!'}),200
@@ -76,14 +49,17 @@ def delete_file(file_name) -> dict: # Json dict, redirect
 
 
         except FileNotFoundError:
-            return jsonify({'message':f'¡File or directory not found!'}),404
+            return jsonify({'message':'¡File not found!'}),404
                 
+
     
-    return jsonify({'message':f'¡File or directory not found!'}),404
+    return redirect('/')
  
 @file_bp.route('/', methods=['GET'])
 @file_bp.route('/<path:url>', methods=['GET'])
 def all_files(url='/') -> dict: # Json dict  
+
+    start_count = datetime.now()
 
     all_files_and_directories = {}
     base_path = current_app.config['UPLOADED_FILES'] 
@@ -94,10 +70,9 @@ def all_files(url='/') -> dict: # Json dict
         try:
             final_path = os.path.join(base_path, url.strip('/'))
             all_files_and_directories['path']        = ('/api'+url if url == '/' else '/api'+'/'+url)
-            all_files_and_directories['files']       = [{'name':f,'type':get_filetype(final_path + '/' + f),'size':get_path_size(final_path + '/' + f)} for f in os.listdir(final_path) if os.path.isfile(os.path.join(final_path, f))] 
-            all_files_and_directories['directories'] = sorted([{'isEmpty': have_files(final_path + '/' + d), 'name':d, 'size':get_path_size(final_path + '/' + d)} for d in os.listdir(final_path) if os.path.isdir(os.path.join(final_path, d))], key= lambda x: x['isEmpty'], reverse=True)
-            if url != '/': # Operations are not allowed in the root path '/'.
-                all_files_and_directories['actions']   = [{'label':'Delete', 'method':'DELETE', 'url':'/api/'+url}, {'label':'Rename', 'method':'PATCH', 'url':'/api/'+url+'/old_name/new_name'}]
+            all_files_and_directories['files']       = [{'name':f,'type':get_filetype(final_path + '/' + f)} for f in os.listdir(final_path) if os.path.isfile(os.path.join(final_path, f))] 
+            all_files_and_directories['directories'] = [{'isEmpty': have_files(final_path + '/' + d), 'name':d} for d in os.listdir(final_path) if os.path.isdir(os.path.join(final_path, d))]
+            all_files_and_directories['actions']     = {'label':'Delete', 'method':'DELETE', 'url':('/api'+url if url == '/' else '/api'+'/'+url)}
 
         except FileNotFoundError:
 
@@ -107,6 +82,13 @@ def all_files(url='/') -> dict: # Json dict
     else:
         return jsonify({'error': 'Path not allowed'}), 404
     
+    end_count = datetime.now()
+
+    response_time = end_count - start_count
+
+    debug_message(f" Request /api/ : Arg path value '{url}' : Response time {response_time}",current_app.config['DEBUG_MODE'])
+
+
     return jsonify(all_files_and_directories)
 
 def check_files_thread(app,sid):
@@ -121,6 +103,7 @@ def check_files_thread(app,sid):
             if new_files != aux_new_files:
                 aux_new_files = new_files
                 socketio.emit('new_files', {'message': 'Nuevo archivo'}, to=sid)
+
 
 @socketio.on('connect')
 def on_connect():

--- a/backend/app/static/js/filesManager.js
+++ b/backend/app/static/js/filesManager.js
@@ -25,7 +25,7 @@ function generateDirectoriesHTML(response,pathDirectory) {
         const haveDirectories = folder['isEmpty'];
         const sanitizedPath = removeSpaces(pathDirectory+'/'+folderName);
         htmlDirectories +=             `<div class="col text-center">
-        <img onclick=refreshFiles("${sanitizedPath}") src="/static/img/${ haveDirectories === true ? 'folder_with_files.png' : 'open-folder.png' }" alt="Logo" width="55" height="55"
+        <img onclick=refreshFiles("${sanitizedPath}") src="/static/img/${ haveDirectories === true ? 'open-folder.png' : 'folder_with_files.png' }" alt="Logo" width="55" height="55"
             style="margin-top: 10px;">
         <h5 class="text-dracula fs-6 mt-2">${folderName}</h5>
     </div>`;

--- a/backend/app/utils/filesystem.py
+++ b/backend/app/utils/filesystem.py
@@ -56,3 +56,12 @@ def get_path_size(path) -> int:
     return total_size
 
 
+def delete_first_bar(path):
+
+    if path[0] == '/':
+        path = path.split('/')
+        path.pop(0)
+        path = '/'.join(path)
+        return path
+    else:
+        return False

--- a/backend/app/utils/filesystem.py
+++ b/backend/app/utils/filesystem.py
@@ -33,7 +33,7 @@ def get_total_files_and_directories(path) -> int:
 
 def have_files(path) -> bool:
 
-    return (True if len(os.listdir(path)) >= 1 else False) 
+    return (False if len(os.listdir(path)) >= 1 else True) 
 
 def get_filetype(file) -> str:
 
@@ -54,3 +54,5 @@ def get_path_size(path) -> int:
                 total_size += os.path.getsize(fp)
 
     return total_size
+
+


### PR DESCRIPTION
En esta feature se agrego un nuevo endpoint 'size', el mismo fue pensado para situaciones de "baja demanda". Antes el tamaño se adjuntaba al consultar una ruta el problema es que si la misma tenia muchos directorios podría llegar a demorar hasta 30 segundos en responder. 

Para eso se implemento este nuevo endpoint "size" el cual se invoca por GET, el mismo espera un parámetro llamado 'path' su uso es el siguiente: 

`curl -X GET localhost:5000/api/size?path=/carpeta/file.txt`

Respuesta:
```
    {
      "name": "file.txt",
      "path": "/carpeta/file.txt",
      "size": 234
    } 
```
Se pueden consultar tanto archivos como carpetas, de la misma forma:
`curl -X GET localhost:5000/api/size?path=/carpeta`
```
    {
      "name": "file.txt",
      "path": "/carpeta/file.txt",
      "size": 234 
    } 
```
Importante aclarar que el valor size se encuentra en la unidad kb.


